### PR TITLE
Adding position info count by magic number

### DIFF
--- a/Include/Orchard/Frameworks/Framework_3.06/Trade/PositionInfo_mql4.mqh
+++ b/Include/Orchard/Frameworks/Framework_3.06/Trade/PositionInfo_mql4.mqh
@@ -69,4 +69,26 @@ class CPositionInfoCustom : public CPositionInfo {
 
 public:
    int Total() { return ( OrdersTotal() ); }
+   int Count( const string symbol, int magic_number );
+};
+
+int CPositionInfo::Count(string symbol, int magic_number)
+{
+   int positionCount = 0; // Counter for positions
+   
+   // Loop through all open orders
+   for(int i = OrdersTotal() - 1; i >= 0; i--)
+   {
+      // Select order by position
+      if(OrderSelect(i, SELECT_BY_POS, MODE_TRADES))
+      {
+         // Check if order matches symbol and magic number
+         if(OrderSymbol() == symbol && OrderMagicNumber() == magic_number)
+         {
+            positionCount++;
+         }
+      }
+   }
+   
+   return(positionCount);
 };

--- a/Include/Orchard/Frameworks/Framework_3.06/Trade/PositionInfo_mql5.mqh
+++ b/Include/Orchard/Frameworks/Framework_3.06/Trade/PositionInfo_mql5.mqh
@@ -36,4 +36,25 @@ class CPositionInfoCustom : public CPositionInfo {
 
 public:
    int Total() { return ( PositionsTotal() ); }
+   int Count( const string symbol, int magic_number );
+};
+
+int CPositionInfoCustom::Count( const string symbol, int magic_number  ) {
+   CPositionInfo positionInfo; // Create an instance of CPositionInfo
+   int positionCount = 0; // Counter for positions on the current symbol
+   // Loop through all open positions
+   for(int i = PositionsTotal() - 1; i >= 0; i--)
+   {
+      // Select position by index
+      ulong ticket = PositionGetTicket(i);
+      if(positionInfo.SelectByTicket(ticket))
+      {
+         // Check if the position is for the current symbol
+         if(positionInfo.Symbol() == symbol && positionInfo.Magic() == magic_number)
+         {
+            positionCount++;
+         }
+      }
+   }
+   return (positionCount);
 };


### PR DESCRIPTION
I love to count the position with magic number that can seprate me and bot trading. However i did test on mqh5 only this request may need to help verify on mqh4 version as well even i did submit both version.

Effect only Framework 3.06, CPositionInfoCustom
Usage: PositionInfo.Count(Symbol(), InpMagic) return the number of open order.